### PR TITLE
Phase 3 - User Details and Stats

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -15,10 +15,9 @@ module Api
     end
 
     def show
-      render json: {
-        user_id: current_user.id,
-        user_email: current_user.email
-      }
+      user_info, _ = RetrieveUserInfo.new.call(current_user)
+
+      render json: {user: user_info}
     end
 
     def game_events

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   validates :password, presence: true, length: {minimum: 6}
 
   has_many :game_events
+  has_many :games, -> { distinct }, through: :game_events
 end

--- a/app/use_cases/retrieve_user_info.rb
+++ b/app/use_cases/retrieve_user_info.rb
@@ -1,0 +1,10 @@
+class RetrieveUserInfo
+  def call(user)
+    info = {
+      id: user.id,
+      email: user.email
+    }
+
+    [info, nil]
+  end
+end

--- a/app/use_cases/retrieve_user_info.rb
+++ b/app/use_cases/retrieve_user_info.rb
@@ -2,7 +2,8 @@ class RetrieveUserInfo
   def call(user)
     info = {
       id: user.id,
-      email: user.email
+      email: user.email,
+      stats: {total_games_played: user.games.count}
     }
 
     [info, nil]

--- a/spec/controllers/api/users_controllers_spec.rb
+++ b/spec/controllers/api/users_controllers_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe Api::UsersController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body)
-      expect(body).to match({
-        "user_id" => user.id,
-        "user_email" => user.email
+      expect(body["user"]).to match({
+        "id" => user.id,
+        "email" => user.email
       })
     end
 

--- a/spec/controllers/api/users_controllers_spec.rb
+++ b/spec/controllers/api/users_controllers_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Api::UsersController, type: :controller do
 
   context "showing current user info" do
     it "returns 200 OK with logged user info" do
-      user = create(:user)
+      user = create(:user, :with_game_event, game_events_count: 2)
       signin(user)
 
       get :show
@@ -45,7 +45,10 @@ RSpec.describe Api::UsersController, type: :controller do
       body = JSON.parse(response.body)
       expect(body["user"]).to match({
         "id" => user.id,
-        "email" => user.email
+        "email" => user.email,
+        "stats" => {
+          "total_games_played" => 2
+        }
       })
     end
 

--- a/spec/factories/game_event.rb
+++ b/spec/factories/game_event.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :game_event do
+    association :user
+    association :game
+    event_type { "COMPLETED" }
+    occurred_at { DateTime.now }
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,5 +2,14 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "email#{n}@example.com" }
     password { SecureRandom.hex(10) }
+
+    trait :with_game_event do
+      transient do
+        game_events_count { 1 }
+      end
+      after(:create) do |user, evaluator|
+        create_list(:game_event, evaluator.game_events_count, user: user)
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe User, type: :model do
     user = create(:user)
     game1 = create(:game)
     game2 = create(:game)
-    game_event1 = create(:game_event, user:, game: game1)
-    game_event2 = create(:game_event, user:, game: game1)
-    game_event3 = create(:game_event, user:, game: game2)
+    create(:game_event, user:, game: game1)
+    create(:game_event, user:, game: game1)
+    create(:game_event, user:, game: game2)
 
     expect(user.games.count).to eq 2
     expect(user.games).to contain_exactly(game1, game2)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,4 +51,16 @@ RSpec.describe User, type: :model do
     expect(user).not_to be_valid
     expect(user.errors.full_messages).to include("Email has already been taken")
   end
+
+  it "retrieves all user games (distinct)" do
+    user = create(:user)
+    game1 = create(:game)
+    game2 = create(:game)
+    game_event1 = create(:game_event, user:, game: game1)
+    game_event2 = create(:game_event, user:, game: game1)
+    game_event3 = create(:game_event, user:, game: game2)
+
+    expect(user.games.count).to eq 2
+    expect(user.games).to contain_exactly(game1, game2)
+  end
 end

--- a/spec/use_cases/retrieve_user_info_spec.rb
+++ b/spec/use_cases/retrieve_user_info_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe RetrieveUserInfo do
+  it "returns current user id and email" do
+    user = double(User, id: 1, email: "email@example.com")
+
+    result, err = described_class.new.call(user)
+
+    expect(result[:id]).to eq user.id
+    expect(result[:email]).to eq user.email
+    expect(err).to be_nil
+  end
+end

--- a/spec/use_cases/retrieve_user_info_spec.rb
+++ b/spec/use_cases/retrieve_user_info_spec.rb
@@ -1,13 +1,17 @@
 require "rails_helper"
 
 RSpec.describe RetrieveUserInfo do
-  it "returns current user id and email" do
+  it "returns current user info" do
+    games = [double(Game), double(Game)]
     user = double(User, id: 1, email: "email@example.com")
+
+    allow(user).to receive(:games).and_return(games)
 
     result, err = described_class.new.call(user)
 
     expect(result[:id]).to eq user.id
     expect(result[:email]).to eq user.email
+    expect(result[:stats][:total_games_played]).to eq games.count
     expect(err).to be_nil
   end
 end


### PR DESCRIPTION
# Phase 3 - User Details and Stats

## What has been done:
`GET /api/user` was already implemented on #1, so I only had to add a way to retrieve games from current user.

## Decision process:
**Decision 1:**
Challenge description does not specify what we should consider as `total_games_played` so I assumed it's a count of distinct events that user has played, regardless of status and of how many times the user played that game. Should this definition change, I'd have to adjust the code accordingly.

**Decision 2:**
Anticipating phase 4, where I'll need to add some more attributes to the user response, I already created an Use Case responsible to retrieve all user info. Since the user itself is already retrieved within authentication, the use case is meant to look for other info regarding the user.
Additionally, right now this use case won't ever return any errors, but I'm still returning it as nil to keep consistency between this and other use cases.